### PR TITLE
AART-2985 Added logic to force CVX to be unique in forecast

### DIFF
--- a/src/main/java/org/immregistries/iis/kernal/logic/IncomingMessageHandler.java
+++ b/src/main/java/org/immregistries/iis/kernal/logic/IncomingMessageHandler.java
@@ -9,6 +9,7 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -1595,7 +1596,13 @@ public class IncomingMessageHandler {
         // RXA-20
         sb.append("|NA");
         sb.append("\r");
+        HashSet<String> cvxAddedSet = new HashSet<String>();
         for (ForecastActual forecastActual : forecastActualList) {
+          String cvx = forecastActual.getVaccineGroup().getVaccineCvx();
+          if (cvxAddedSet.contains(cvx)) {
+            continue;
+          }
+          cvxAddedSet.add(cvx);
           obsSubId++;
           {
             obxSetId++;
@@ -2111,7 +2118,7 @@ public class IncomingMessageHandler {
       }
       testCase.setTestEventList(testEventList);
       Software software = new Software();
-      software.setServiceUrl("https://florence.immregistries.org/lonestar/forecast");
+      software.setServiceUrl("https://sabbia.westus2.cloudapp.azure.com/lonestar/forecast");
       software.setService(Service.LSVF);
       if (processingFlavorSet.contains(ProcessingFlavor.ICE)) {
         software.setServiceUrl(


### PR DESCRIPTION
This ensures that for the forecast, only one unique CVX code is returned. The underlying logic that we use to connect to forecasters, such as LoneStarForecaster duplicate the information coming back to represent in different ways. This explains why DTaP comes back twice with the same code. This duplication doesn't explain why we saw some of the vaccines many times. This fix will ensure that no matter what happens there will not be duplicates coming out of IIS Sandbox.

Also, I update the URL to the forecaster. It's hardcoded in the IIS Sandbox. Not ideal, but wonder how this was fixed in production. Now it is fixed in the base code, so that's probably good enough for now. 